### PR TITLE
Build ubuntu qa

### DIFF
--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -52,13 +52,13 @@ jobs:
     - uses: actions/checkout@v4
     - name: scala-bionic
       run: docker build . --file ./scala/build/bionic.Dockerfile --tag "scala-bionic:$(date +%s)"
-      
-  build-scala-mantic:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - name: scala-mantic
-      run: docker build . --file ./scala/build/Dockerfile.mantic --tag "scala-mantic:$(date +%s)" 
+  # Deprecated - v2024.4.1
+  # build-scala-mantic:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - name: scala-mantic
+  #     run: docker build . --file ./scala/build/mantic.Dockerfile --tag "scala-mantic:$(date +%s)" 
   build-scala-maintenance:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
         id: push
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
         with:
-          context: ./ubuntu/latest.Dockerfile
+          context: . --file ./ubuntu/latest.Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
         Get-Process
 
   # QA
-  # Ubuntu for QA
+  # Build Ubuntu for QA
   build-ubuntu-qa:
     runs-on: ubuntu-latest
     steps:
@@ -119,7 +119,7 @@ jobs:
       run: docker build . --file ./qa/build/scala.Dockerfile --tag "qa-scals:$(date +%s)"
   
   # PROGRAMMING LANGUAGE
-  # PHP
+  # Build latest PHP version
   build-php-latest:
     runs-on: ubuntu-latest
     steps:
@@ -133,7 +133,7 @@ jobs:
     - name: php-fpm
       run: docker build . --file ./php/beta.Dockerfile --tag "php:$(date +%s)"
 
-  # SCALA
+  # Build latest SCALA version
   build-scala-latest:
     runs-on: ubuntu-latest
     steps:
@@ -146,12 +146,14 @@ jobs:
     - uses: actions/checkout@v4
     - name: scala-bionic
       run: docker build . --file ./scala/build/bionic.Dockerfile --tag "scala-bionic:$(date +%s)"
-  build-scala-mantic:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - name: scala-mantic
-      run: docker build . --file ./scala/build/mantic.Dockerfile --tag "scala-mantic:$(date +%s)"
+  # Deprecated - v2024.4.1
+  # build-scala-mantic:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #   - uses: actions/checkout@v4
+  #   - name: scala-mantic
+  #     run: docker build . --file ./scala/build/mantic.Dockerfile --tag "scala-mantic:$(date +%s)"
+  # Build maintenance SCALA version
   build-scala-maintenance:
     runs-on: ubuntu-latest
     steps:
@@ -160,7 +162,7 @@ jobs:
       run: docker build . --file ./scala/build/maintenance.Dockerfile --tag "scala-maintenance:$(date +%s)"
   
   # APPLICATIONS
-  # JENKINS
+  # Build latest JENKINS version
   build-jenkins-latest:
     runs-on: ubuntu-latest
     steps:
@@ -169,6 +171,7 @@ jobs:
       run: docker build . --file ./jenkins/latest.Dockerfile --tag "jenkins-latest:$(date +%s)"
 
   # PUPPETEER
+  # Build latest PUPPETEER version
   build-puppeteer-latest:
     runs-on: ubuntu-latest
     steps:
@@ -178,6 +181,7 @@ jobs:
 
   # TEST
   # API TEST WITH POSTMAN
+  # MacOS: curl -sL https://dl-cli.pstmn.io/install/osx_64.sh | bash
   # https://cloudy-shadow-800513.postman.co/workspace/lecaoquochung~885e6b40-0422-488c-8ab6-2f85ee3179ca/api/1512548b-2196-422a-8a3c-b8d374f227f9?action=share&creator=15804725&active-environment=15804725-addaf00d-1d92-4909-9256-0fa91ac840ac
   test-postman:
     needs: build-ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
   push_to_registries:
     name: Push Docker image to multiple registries
     runs-on: ubuntu-latest
+    environment: CI
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ "main" ]
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
   inspect-code:
     name: '[Required] Inspect code'
@@ -88,9 +92,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: |
-            lecaoquochung/docker-images
-            ghcr.io/${{ github.repository }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker images
         id: push

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,14 +43,17 @@ jobs:
       run: |
         #docker login --username ${{ github.actor }} --password ${{ secrets.GITHUB_PAT }} ghcr.io 
         docker login --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} ghcr.io  
-        docker build . --file ./ubuntu/latest.Dockerfile --tag ghcr.io/lecaqquochung/ubuntu-latest:latest
+        docker build . --file ./ubuntu/latest.Dockerfile --tag "ghcr.io/lecaqquochung/ubuntu-latest:latest"
+        # docker tag ghcr.io/lecaqquochung/ubuntu-latest:latest ghcr.io/lecaqquochung/ubuntu-latest:latest
         docker push ghcr.io/lecaoquochung/ubuntu-latest:latest
     - name: ubuntu-lastest
       run: |
         # docker build . --file ./ubuntu/latest.Dockerfile --tag "ubuntu-latest:$(date +%Y-%m-%d_%H:%M:%S)"
         # docker login --username lecaoquochung --password ${{ secrets.GITHUB_TOKEN }} ghcr.io
         docker login --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} ghcr.io  
-        docker build . --file ./ubuntu/latest.Dockerfile --tag "ghcr.io/lecaoquochung/ubuntu-latest:${{ env.DATE_TIME }}"
+        docker build . \ 
+          --file ./ubuntu/latest.Dockerfile \ 
+          --tag "ghcr.io/lecaoquochung/ubuntu-latest:${{ env.DATE_TIME }}"
         # docker push ubuntu-latest:${{ env.DATE_TIME }}
         docker push ghcr.io/lecaoquochung/ubuntu-latest:${{ env.DATE_TIME }} 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         docker build . --file ./ubuntu/latest.Dockerfile --tag "lecaoquochung/docker-images:ubuntu-latest-${{ env.DATE_TIME }}"
         docker images
         # docker tag "lecaoquochung/docker-images:ubuntu-latest-${{ env.DATE_TIME }}" "ghcr.io/lecaoquochung/docker-images:ubuntu-latest-${{ env.DATE_TIME }}"
-        docker push "ghcr.io/lecaoquochung/docker-images:ubuntu-latest-${{ env.DATE_TIME }}"
+        docker push "lecaoquochung/docker-images:ubuntu-latest-${{ env.DATE_TIME }}"
     - name: ubuntu-lastest
       run: |
         # docker build . --file ./ubuntu/latest.Dockerfile --tag "ubuntu-latest:$(date +%Y-%m-%d-%H:%M:%S)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,8 @@ jobs:
 
   # OS 
   # Ubuntu
-  build-ubuntu-latest:
+  build-ubuntu-latest-manual:
+    name: '[Manual] Build Ubuntu latest'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -59,11 +60,10 @@ jobs:
         docker build . --file ./ubuntu/latest.Dockerfile --tag "ghcr.io/lecaoquochung/docker-images:ubuntu-latest-${{ env.DATE_TIME }}"
         docker images
         # docker push ubuntu-latest:${{ env.DATE_TIME }}
-        # docker push ghcr.io/lecaoquochung/ubuntu-latest:${{ env.DATE_TIME }} 
+        # docker push ghcr.io/lecaoquochung/ubuntu-latest:${{ env.DATE_TIME }}
   
-  # https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-docker-images
-  push_to_registries:
-    name: Push Docker image to multiple registries
+  build-ubuntu-latest:
+    name: '[Auto] Build Ubuntu latest'
     runs-on: ubuntu-latest
     environment: CI
     permissions:
@@ -75,6 +75,9 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
+      - name: Set up date and time variable
+        run: echo "DATE_TIME=$(date '+%Y-%m-%d-%H-%M-%S')" >> $GITHUB_ENV
+      
       - name: Log in to Docker Hub
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
         with:
@@ -87,12 +90,21 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
+      
+      # https://github.com/docker/metadata-action
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        # uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7 # using hash
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,${{ env.DATE_TIME }}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=schedule,pattern={{date 'YYYYMMDD-hhmmss' tz='Asia/Tokyo'}}
+            type=semver,pattern={{raw}}
+            # type=sha # Can be used with released
 
       - name: Build and push Docker images
         id: push

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
   automation:
     name: 'Automation workflow'
     runs-on: ubuntu-latest
+    environment: CI
     steps:
       - name: Check out repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
         #docker login --username ${{ github.actor }} --password ${{ secrets.GITHUB_PAT }} ghcr.io 
         docker login --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} ghcr.io  
         docker build . --file ./ubuntu/latest.Dockerfile --tag "ubuntu-latest-latest"
+        docker images | grep ghcr.io/lecaqquochung/docker-images
         # docker tag ghcr.io/lecaqquochung/ubuntu-latest:latest ghcr.io/lecaqquochung/ubuntu-latest:latest
         docker push ghcr.io/lecaoquochung/docker-images:ubuntu-latest-latest
     - name: ubuntu-lastest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,9 @@ jobs:
         #docker login --username ${{ github.actor }} --password ${{ secrets.GITHUB_PAT }} ghcr.io 
         docker login --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} ghcr.io  
         docker build . --file ./ubuntu/latest.Dockerfile --tag "ubuntu-latest-latest"
-        docker images | grep ghcr.io/lecaqquochung/docker-images
+        docker images
         # docker tag ghcr.io/lecaqquochung/ubuntu-latest:latest ghcr.io/lecaqquochung/ubuntu-latest:latest
-        docker push ghcr.io/lecaoquochung/docker-images:ubuntu-latest-latest
+        # docker push ghcr.io/lecaoquochung/docker-images:ubuntu-latest-latest
     - name: ubuntu-lastest
       run: |
         # docker build . --file ./ubuntu/latest.Dockerfile --tag "ubuntu-latest:$(date +%Y-%m-%d_%H:%M:%S)"
@@ -55,8 +55,9 @@ jobs:
         docker build . \ 
           --file ./ubuntu/latest.Dockerfile \ 
           --tag "ghcr.io/lecaoquochung/ubuntu-latest:${{ env.DATE_TIME }}"
+        docker images
         # docker push ubuntu-latest:${{ env.DATE_TIME }}
-        docker push ghcr.io/lecaoquochung/ubuntu-latest:${{ env.DATE_TIME }} 
+        # docker push ghcr.io/lecaoquochung/ubuntu-latest:${{ env.DATE_TIME }} 
 
   # MacOS
   # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,52 @@ jobs:
           TEST: true
       - name: Check code
         run: ls -all
+  
+  manual:
+    name: 'Manual workflow'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          fetch-depth: 2
+      - name: Set up Node.js
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
+        with:
+          cache: npm
+          node-version-file: '.nvmrc'
+      - name: Install dependencies
+        run: npm ci
+        env:
+          TEST: true
+      - name: Check code
+        run: ls -all
+
+  automation:
+    name: 'Automation workflow'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          fetch-depth: 2
+      - name: Set up Node.js
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
+        with:
+          cache: npm
+          node-version-file: '.nvmrc'
+      - name: Install dependencies
+        run: npm ci
+        env:
+          TEST: true
+      - name: Check code
+        run: ls -all
 
   # OS 
   # Ubuntu
   build-ubuntu-latest-manual:
     name: '[Manual] Build Ubuntu latest'
+    needs: manual
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -64,6 +105,7 @@ jobs:
   
   build-ubuntu-latest:
     name: '[Auto] Build Ubuntu latest'
+    needs: automation
     runs-on: ubuntu-latest
     environment: CI
     permissions:
@@ -125,7 +167,9 @@ jobs:
   
   # MacOS
   # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md
-  build-macos-latest:
+  build-macos-latest-manual:
+    name: '[Manual] Build MacOS latest'
+    needs: manual
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v4
@@ -157,7 +201,9 @@ jobs:
   
   # Windows
   # https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md
-  build-windows-latest:
+  build-windows-latest-manual:
+    name: '[Manual] Build Windows latest'
+    needs: manual
     runs-on: windows-latest
     steps:
     - uses: actions/checkout@v4
@@ -186,19 +232,25 @@ jobs:
 
   # QA
   # Build Ubuntu for QA
-  build-ubuntu-qa:
+  build-ubuntu-qa-manual:
+    name: '[Manual] Build Ubuntu QA'
+    needs: manual
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: ubuntu-qa
       run: docker build . --file ./ubuntu/qa.Dockerfile --tag "ubuntu-qa:$(date +%s)"
-  build-ubuntu-noble:
+  build-ubuntu-noble-manual:
+    name: '[Manual] Build Ubuntu Noble'
+    needs: manual
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: ubuntu-noble
       run: docker build . --file ./ubuntu/noble.Dockerfile --tag "ubuntu-noble:$(date +%s)"
-  build-qa-scala:
+  build-qa-scala-manual:
+    name: '[Manual] Build QA Scala'
+    needs: manual
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -207,13 +259,17 @@ jobs:
   
   # PROGRAMMING LANGUAGE
   # Build latest PHP version
-  build-php-latest:
+  build-php-latest-manual:
+    name: '[Manual] Build PHP latest'
+    needs: manual
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: php-fpm
       run: docker build . --file ./php/latest.Dockerfile --tag "php:$(date +%s)"
-  build-php-beta:
+  build-php-beta-manual:
+    name: '[Manual] Build PHP beta'
+    needs: manual
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -221,13 +277,17 @@ jobs:
       run: docker build . --file ./php/beta.Dockerfile --tag "php:$(date +%s)"
 
   # Build latest SCALA version
-  build-scala-latest:
+  build-scala-latest-manual:
+    name: '[Manual] Build Scala latest'
+    needs: manual
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: scala-latest
       run: docker build . --file ./scala/build/latest.Dockerfile --tag "scala-latest:$(date +%s)" 
-  build-scala-bionic:
+  build-scala-bionic-manual:
+    name: '[Manual] Build Scala bionic'
+    needs: manual
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -241,7 +301,9 @@ jobs:
   #   - name: scala-mantic
   #     run: docker build . --file ./scala/build/mantic.Dockerfile --tag "scala-mantic:$(date +%s)"
   # Build maintenance SCALA version
-  build-scala-maintenance:
+  build-scala-maintenance-manual:
+    name: '[Manual] Build Scala maintenance'
+    needs: manual
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -250,7 +312,9 @@ jobs:
   
   # APPLICATIONS
   # Build latest JENKINS version
-  build-jenkins-latest:
+  build-jenkins-latest-manual:
+    name: '[Manual] Build Jenkins latest'
+    needs: manual
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -259,12 +323,25 @@ jobs:
 
   # PUPPETEER
   # Build latest PUPPETEER version
-  build-puppeteer-latest:
+  build-puppeteer-latest-manual:
+    name: '[Manual] Build Puppeteer latest'
+    needs: manual
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - name: puppeteer-latest
       run: docker build . --file ./puppeteer/latest.Dockerfile --tag "puppeteer-latest:$(date +%s)"
+
+  # REDIS
+  # Build latest REDIS version
+  build-redis-latest-manual:
+    name: '[Manual] Build Redis latest'
+    needs: manual
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: redis-latest
+      run: docker build . --file ./database/redis/latest.Dockerfile --tag "redis-latest:$(date +%s)"
 
   # TEST
   # API TEST WITH POSTMAN
@@ -359,7 +436,7 @@ jobs:
 
   # REDASH SETUP MACOS
   test-redash-setup-macos:
-    needs: build-macos-latest
+    needs: build-macos-latest-manual
     runs-on: macos-latest
     environment: CI
     steps:
@@ -392,7 +469,7 @@ jobs:
 
   # TEST REDASH DOCKER
   test-redash-docker:
-    needs: build-windows-latest
+    needs: build-windows-latest-manual
     runs-on: windows-latest
     environment: CI
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,9 +43,9 @@ jobs:
       run: |
         #docker login --username ${{ github.actor }} --password ${{ secrets.GITHUB_PAT }} ghcr.io 
         docker login --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} ghcr.io  
-        docker build . --file ./ubuntu/latest.Dockerfile --tag "ghcr.io/lecaqquochung/ubuntu-latest:latest"
+        docker build . --file ./ubuntu/latest.Dockerfile --tag "ubuntu-latest-latest"
         # docker tag ghcr.io/lecaqquochung/ubuntu-latest:latest ghcr.io/lecaqquochung/ubuntu-latest:latest
-        docker push ghcr.io/lecaoquochung/ubuntu-latest:latest
+        docker push ghcr.io/lecaoquochung/docker-images:ubuntu-latest-latest
     - name: ubuntu-lastest
       run: |
         # docker build . --file ./ubuntu/latest.Dockerfile --tag "ubuntu-latest:$(date +%Y-%m-%d_%H:%M:%S)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,21 +34,25 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up date and time variable
-      run: echo "DATE_TIME=$(date +%Y-%m-%d_%H-%M-%S)" >> $GITHUB_ENV
+      run: echo "DATE_TIME=$(date '+%Y-%m-%d_%H-%M-%S')" >> $GITHUB_ENV 
     - name: Output date and time
       run: |
+        ls -all;pwd;whoami;
         echo "Date and Time: ${{ env.DATE_TIME }}"
     - name: Test build
       run: |
-        docker login --username lecaoquochung --password ${{ secrets.GITHUB_TOKEN }} ghcr.io
+        #docker login --username ${{ github.actor }} --password ${{ secrets.GITHUB_PAT }} ghcr.io 
+        docker login --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} ghcr.io  
         docker build . --tag ghcr.io/lecaqquochung/ubuntu-latest:latest
         docker push ghcr.io/lecaoquochung/ubuntu-latest:latest
     - name: ubuntu-lastest
       run: |
         # docker build . --file ./ubuntu/latest.Dockerfile --tag "ubuntu-latest:$(date +%Y-%m-%d_%H:%M:%S)"
-        docker login --username lecaoquochung --password ${{ secrets.GITHUB_TOKEN }} ghcr.io
-        docker build . --file ./ubuntu/latest.Dockerfile --tag "ubuntu-latest:${{ env.DATE_TIME }}"
-        docker push ubuntu-latest:${{ env.DATE_TIME }}
+        # docker login --username lecaoquochung --password ${{ secrets.GITHUB_TOKEN }} ghcr.io
+        docker login --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} ghcr.io  
+        docker build . --file ./ubuntu/latest.Dockerfile --tag "ghcr.io/lecaoquochung/ubuntu-latest:${{ env.DATE_TIME }}"
+        # docker push ubuntu-latest:${{ env.DATE_TIME }}
+        docker push ghcr.io/lecaoquochung/ubuntu-latest:${{ env.DATE_TIME }} 
 
   # MacOS
   # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - name: Set up date and time variable
+      run: echo "DATE_TIME=$(date +%Y-%m-%d_%H-%M-%S)" >> $GITHUB_ENV
+    - name: Output date and time
+      run: |
+        echo "Date and Time: ${{ env.DATE_TIME }}"
+    - name: Test build
+      run: |
+        docker build . --tag ghcr.io/lecaqquochung/ubuntu-latest:latest
+        docker push ghcr.io/lecaoquochung/ubuntu-latest:latest
     - name: ubuntu-lastest
-      run: docker build . --file ./ubuntu/latest.Dockerfile --tag "ubuntu-latest:$(date +%s)"
-  
+      run: |
+        # docker build . --file ./ubuntu/latest.Dockerfile --tag "ubuntu-latest:$(date +%Y-%m-%d_%H:%M:%S)"
+        docker build . --file ./ubuntu/latest.Dockerfile --tag "ubuntu-latest:${{ env.DATE_TIME }}"
+        docker push ubuntu-latest:${{ env.DATE_TIME }}
+
   # MacOS
   # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md
   build-macos-latest:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         docker build . --file ./ubuntu/latest.Dockerfile --tag "lecaoquochung/docker-images:ubuntu-latest-${{ env.DATE_TIME }}"
         docker images
         # docker tag "lecaoquochung/docker-images:ubuntu-latest-${{ env.DATE_TIME }}" "ghcr.io/lecaoquochung/docker-images:ubuntu-latest-${{ env.DATE_TIME }}"
-        docker push "lecaoquochung/docker-images:ubuntu-latest-${{ env.DATE_TIME }}"
+        # docker push "lecaoquochung/docker-images:ubuntu-latest-${{ env.DATE_TIME }}"
     - name: ubuntu-lastest
       run: |
         # docker build . --file ./ubuntu/latest.Dockerfile --tag "ubuntu-latest:$(date +%Y-%m-%d-%H:%M:%S)"
@@ -56,7 +56,57 @@ jobs:
         docker images
         # docker push ubuntu-latest:${{ env.DATE_TIME }}
         # docker push ghcr.io/lecaoquochung/ubuntu-latest:${{ env.DATE_TIME }} 
+  
+  # https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-docker-images
+  push_to_registries:
+    name: Push Docker image to multiple registries
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: |
+            lecaoquochung/docker-images
+            ghcr.io/${{ github.repository }}
+
+      - name: Build and push Docker images
+        id: push
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: ./ubuntu/latest.Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+  
   # MacOS
   # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-arm64-Readme.md
   build-macos-latest:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,8 @@ jobs:
         id: push
         uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
         with:
-          context: . --file ./ubuntu/latest.Dockerfile
+          context: .
+          file: ./ubuntu/latest.Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       run: |
         #docker login --username ${{ github.actor }} --password ${{ secrets.GITHUB_PAT }} ghcr.io 
         docker login --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} ghcr.io  
-        docker build . --tag ghcr.io/lecaqquochung/ubuntu-latest:latest
+        docker build . --file ./ubuntu/latest.Dockerfile --tag ghcr.io/lecaqquochung/ubuntu-latest:latest
         docker push ghcr.io/lecaoquochung/ubuntu-latest:latest
     - name: ubuntu-lastest
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       run: |
         #docker login --username ${{ github.actor }} --password ${{ secrets.GITHUB_PAT }} ghcr.io 
         docker login --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} ghcr.io  
-        docker build . --file ./ubuntu/latest.Dockerfile --tag "docker-images:ubuntu-latest-${{ env.DATE_TIME }}"
+        docker build . --file ./ubuntu/latest.Dockerfile --tag "lecaoquochung/docker-images:ubuntu-latest-${{ env.DATE_TIME }}"
         docker images
         # docker tag ghcr.io/lecaqquochung/ubuntu-latest:latest ghcr.io/lecaqquochung/ubuntu-latest:latest
         docker push ghcr.io/lecaoquochung/docker-images:ubuntu-latest-${{ env.DATE_TIME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,14 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  IMAGE_AUTOMATION_TEST: automation-test
+  IMAGE_UBUNTU: ubuntu-latest
+  IMAGE_PHP: php-latest
 
 jobs:
+  # job inspect-code
   inspect-code:
-    name: '[Required] Inspect code'
+    name: 'Inspect code'
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -31,6 +35,7 @@ jobs:
       - name: Check code
         run: ls -all
   
+  # job manual, workflow manual
   manual:
     name: 'Manual workflow'
     runs-on: ubuntu-latest
@@ -50,7 +55,8 @@ jobs:
           TEST: true
       - name: Check code
         run: ls -all
-
+  
+  # job automation, workflow automation
   automation:
     name: 'Automation workflow'
     runs-on: ubuntu-latest
@@ -70,9 +76,38 @@ jobs:
           TEST: true
       - name: Check code
         run: ls -all
-
+      - name: Set up date and time variable
+        run: echo "DATE_TIME=$(TZ='Asia/Tokyo' date '+%Y-%m-%d-%H-%M-%S')" >> $GITHUB_ENV
+      - name: Log in to Docker Hub # https://github.com/docker/login-action
+        # uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a 
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Log in to the Container registry # https://github.com/docker/login-action
+        # uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker # https://github.com/docker/metadata-action
+        id: meta
+        # uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7 # using hash
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,${{ env.IMAGE_AUTOMATION_TEST }}-${{ env.DATE_TIME }}
+            type=ref,enable=true,priority=600,prefix=${{ env.IMAGE_AUTOMATION_TEST }}-,event=branch
+            type=ref,enable=true,priority=600,prefix=${{ env.IMAGE_AUTOMATION_TEST }}-,event=pr
+            type=schedule,pattern={{date 'YYYYMMDD-hhmmss' tz='Asia/Tokyo'}}
+            type=semver,pattern={{raw}} # TODO release only
+            type=sha # TODO release only
+      
   # OS 
-  # Ubuntu
+  # Ubuntu - manual build and test
+  # job build ubuntu latest manual
   build-ubuntu-latest-manual:
     name: '[Manual] Build Ubuntu latest'
     needs: manual
@@ -80,7 +115,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up date and time variable
-      run: echo "DATE_TIME=$(date '+%Y-%m-%d-%H-%M-%S')" >> $GITHUB_ENV 
+      run: echo "DATE_TIME=$(TZ='Asia/Tokyo' date '+%Y-%m-%d-%H-%M-%S')" >> $GITHUB_ENV
     - name: Output date and time
       run: |
         ls -all;pwd;whoami;
@@ -103,6 +138,7 @@ jobs:
         # docker push ubuntu-latest:${{ env.DATE_TIME }}
         # docker push ghcr.io/lecaoquochung/ubuntu-latest:${{ env.DATE_TIME }}
   
+  # Ubuntu - automation build and push
   build-ubuntu-latest:
     name: '[Auto] Build Ubuntu latest'
     needs: automation
@@ -116,48 +152,44 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
-
       - name: Set up date and time variable
-        run: echo "DATE_TIME=$(date '+%Y-%m-%d-%H-%M-%S')" >> $GITHUB_ENV
-      
-      - name: Log in to Docker Hub
-        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        run: echo "DATE_TIME=$(TZ='Asia/Tokyo' date '+%Y-%m-%d-%H-%M-%S')" >> $GITHUB_ENV
+      - name: Log in to Docker Hub # https://github.com/docker/login-action
+        # uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a 
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+      - name: Log in to the Container registry # https://github.com/docker/login-action
+        # uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      
-      # https://github.com/docker/metadata-action
-      - name: Extract metadata (tags, labels) for Docker
+      - name: Extract metadata (tags, labels) for Docker # https://github.com/docker/metadata-action
         id: meta
         # uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7 # using hash
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,${{ env.DATE_TIME }}
-            type=ref,event=branch
-            type=ref,event=pr
-            type=schedule,pattern={{date 'YYYYMMDD-hhmmss' tz='Asia/Tokyo'}}
-            type=semver,pattern={{raw}}
-            # type=sha # Can be used with released
-
-      - name: Build and push Docker images
+            type=raw,${{ env.IMAGE_UBUNTU }}-${{ env.DATE_TIME }}
+            type=ref,enable=true,priority=600,prefix=${{ env.IMAGE_UBUNTU }}-,event=branch
+            type=ref,enable=true,priority=600,prefix=${{ env.IMAGE_UBUNTU }}-,event=pr
+            # type=schedule,pattern={{date 'YYYYMMDD-hhmmss' tz='Asia/Tokyo'}}
+            # type=semver,pattern={{raw}} # TODO release only
+            # type=sha # TODO release only
+      - name: Build and push Docker images # https://github.com/docker/build-push-action
         id: push
-        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        # uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./ubuntu/latest.Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
@@ -267,6 +299,58 @@ jobs:
     - uses: actions/checkout@v4
     - name: php-fpm
       run: docker build . --file ./php/latest.Dockerfile --tag "php:$(date +%s)"
+  
+  build-php-latest:
+    name: '[Auto] Build PHP latest'
+    needs: automation
+    runs-on: ubuntu-latest
+    environment: CI
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+      - name: Set up date and time variable
+        run: echo "DATE_TIME=$(TZ='Asia/Tokyo' date '+%Y-%m-%d-%H-%M-%S')" >> $GITHUB_ENV
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker # https://github.com/docker/metadata-action
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,${{ env.IMAGE_PHP }}-${{ env.DATE_TIME }}
+            type=ref,enable=true,priority=600,prefix=${{ env.IMAGE_PHP }}-,event=branch
+            type=ref,enable=true,priority=600,prefix=${{ env.IMAGE_PHP }}-,event=pr
+      - name: Build and push Docker images
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./php/latest.Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+  
   build-php-beta-manual:
     name: '[Manual] Build PHP beta'
     needs: manual

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,13 @@ jobs:
         echo "Date and Time: ${{ env.DATE_TIME }}"
     - name: Test build
       run: |
+        docker login --username lecaoquochung --password ${{ secrets.GITHUB_TOKEN }} ghcr.io
         docker build . --tag ghcr.io/lecaqquochung/ubuntu-latest:latest
         docker push ghcr.io/lecaoquochung/ubuntu-latest:latest
     - name: ubuntu-lastest
       run: |
         # docker build . --file ./ubuntu/latest.Dockerfile --tag "ubuntu-latest:$(date +%Y-%m-%d_%H:%M:%S)"
+        docker login --username lecaoquochung --password ${{ secrets.GITHUB_TOKEN }} ghcr.io
         docker build . --file ./ubuntu/latest.Dockerfile --tag "ubuntu-latest:${{ env.DATE_TIME }}"
         docker push ubuntu-latest:${{ env.DATE_TIME }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         docker build . --file ./ubuntu/latest.Dockerfile --tag "docker-images:ubuntu-latest-${{ env.DATE_TIME }}"
         docker images
         # docker tag ghcr.io/lecaqquochung/ubuntu-latest:latest ghcr.io/lecaqquochung/ubuntu-latest:latest
-        # docker push ghcr.io/lecaoquochung/docker-images:ubuntu-latest-latest
+        docker push ghcr.io/lecaoquochung/docker-images:ubuntu-latest-${{ env.DATE_TIME }}
     - name: ubuntu-lastest
       run: |
         # docker build . --file ./ubuntu/latest.Dockerfile --tag "ubuntu-latest:$(date +%Y-%m-%d-%H:%M:%S)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up date and time variable
-      run: echo "DATE_TIME=$(date '+%Y-%m-%d_%H-%M-%S')" >> $GITHUB_ENV 
+      run: echo "DATE_TIME=$(date '+%Y-%m-%d-%H-%M-%S')" >> $GITHUB_ENV 
     - name: Output date and time
       run: |
         ls -all;pwd;whoami;
@@ -43,18 +43,16 @@ jobs:
       run: |
         #docker login --username ${{ github.actor }} --password ${{ secrets.GITHUB_PAT }} ghcr.io 
         docker login --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} ghcr.io  
-        docker build . --file ./ubuntu/latest.Dockerfile --tag "ubuntu-latest-latest"
+        docker build . --file ./ubuntu/latest.Dockerfile --tag "docker-images:ubuntu-latest-${{ env.DATE_TIME }}"
         docker images
         # docker tag ghcr.io/lecaqquochung/ubuntu-latest:latest ghcr.io/lecaqquochung/ubuntu-latest:latest
         # docker push ghcr.io/lecaoquochung/docker-images:ubuntu-latest-latest
     - name: ubuntu-lastest
       run: |
-        # docker build . --file ./ubuntu/latest.Dockerfile --tag "ubuntu-latest:$(date +%Y-%m-%d_%H:%M:%S)"
+        # docker build . --file ./ubuntu/latest.Dockerfile --tag "ubuntu-latest:$(date +%Y-%m-%d-%H:%M:%S)"
         # docker login --username lecaoquochung --password ${{ secrets.GITHUB_TOKEN }} ghcr.io
         docker login --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} ghcr.io  
-        docker build . \ 
-          --file ./ubuntu/latest.Dockerfile \ 
-          --tag "ghcr.io/lecaoquochung/ubuntu-latest:${{ env.DATE_TIME }}"
+        docker build . --file ./ubuntu/latest.Dockerfile --tag "ghcr.io/lecaoquochung/docker-images:ubuntu-latest-${{ env.DATE_TIME }}"
         docker images
         # docker push ubuntu-latest:${{ env.DATE_TIME }}
         # docker push ghcr.io/lecaoquochung/ubuntu-latest:${{ env.DATE_TIME }} 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,8 @@ jobs:
         docker login --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} ghcr.io  
         docker build . --file ./ubuntu/latest.Dockerfile --tag "lecaoquochung/docker-images:ubuntu-latest-${{ env.DATE_TIME }}"
         docker images
-        # docker tag ghcr.io/lecaqquochung/ubuntu-latest:latest ghcr.io/lecaqquochung/ubuntu-latest:latest
-        docker push ghcr.io/lecaoquochung/docker-images:ubuntu-latest-${{ env.DATE_TIME }}
+        # docker tag "lecaoquochung/docker-images:ubuntu-latest-${{ env.DATE_TIME }}" "ghcr.io/lecaoquochung/docker-images:ubuntu-latest-${{ env.DATE_TIME }}"
+        docker push "ghcr.io/lecaoquochung/docker-images:ubuntu-latest-${{ env.DATE_TIME }}"
     - name: ubuntu-lastest
       run: |
         # docker build . --file ./ubuntu/latest.Dockerfile --tag "ubuntu-latest:$(date +%Y-%m-%d-%H:%M:%S)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,132 @@
+name: Release
+
+on:
+  release:
+    types:
+      - published
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_AUTOMATION_TEST: automation-test
+  IMAGE_UBUNTU: ubuntu-latest
+  IMAGE_PHP: php-latest
+
+jobs:
+  automation:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
+        name: Publish
+        uses: actions/publish-immutable-action@v0.0.4
+
+  release-ubuntu-latest:
+    name: '[Auto] Release Ubuntu latest'
+    needs: automation
+    runs-on: ubuntu-latest
+    environment: CI
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+      - name: Set up date and time variable
+        run: echo "DATE_TIME=$(TZ='Asia/Tokyo' date '+%Y-%m-%d-%H-%M-%S')" >> $GITHUB_ENV
+      - name: Log in to Docker Hub # https://github.com/docker/login-action
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Log in to the Container registry # https://github.com/docker/login-action
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker # https://github.com/docker/metadata-action
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,${{ env.IMAGE_UBUNTU }}
+            type=ref,enable=true,priority=600,prefix=${{ env.IMAGE_UBUNTU }}-,event=branch
+            type=semver,enable=true,priority=900,prefix=${{ env.IMAGE_UBUNTU }}-,pattern={{raw}}
+            type=sha,enable=true,priority=100,prefix=${{ env.IMAGE_UBUNTU }}-sha-,suffix=,format=short
+      - name: Build and push Docker images # https://github.com/docker/build-push-action
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./ubuntu/latest.Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+  release-php-latest:
+    name: '[Auto] Release PHP latest'
+    needs: automation
+    runs-on: ubuntu-latest
+    environment: CI
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+      - name: Set up date and time variable
+        run: echo "DATE_TIME=$(TZ='Asia/Tokyo' date '+%Y-%m-%d-%H-%M-%S')" >> $GITHUB_ENV
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker # https://github.com/docker/metadata-action
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,${{ env.IMAGE_PHP }}
+            type=ref,enable=true,priority=600,prefix=${{ env.IMAGE_PHP }}-,event=branch
+            type=semver,enable=true,priority=900,prefix=${{ env.IMAGE_PHP }}-,pattern={{raw}}
+            type=sha,enable=true,priority=100,prefix=${{ env.IMAGE_PHP }}-sha-,suffix=,format=short
+      - name: Build and push Docker images
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./php/latest.Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,3 @@
+# This version only using for package.json inspect code
+# This version will not be used in Dockerfile
 v20

--- a/database/redis/latest.Dockerfile
+++ b/database/redis/latest.Dockerfile
@@ -1,0 +1,11 @@
+# https://github.com/redis/docker-library-redis/blob/e5650da99bb377b2ed4f9f1ef993ff24729b1c16/7.4/debian/Dockerfile
+# https://hub.docker.com/_/redis/tags
+FROM redis:latest
+
+LABEL org.opencontainers.image.description DESCRIPTION="Redis latest"
+LABEL org.opencontainers.image.source=https://github.com/lecaoquochung/docker-images/blob/main/ubuntu/latest.Dockerfile
+LABEL org.opencontainers.image.licenses=MIT
+
+# Update package index and install dependencies
+RUN apt-get update && \
+    apt-get install -y git curl iputils-ping telnet vim unzip

--- a/puppeteer/latest.Dockerfile
+++ b/puppeteer/latest.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:21.1.0
+FROM node:22.12.0
 
 WORKDIR /build
 

--- a/qa/build/scala.Dockerfile
+++ b/qa/build/scala.Dockerfile
@@ -46,7 +46,8 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
 
 # Install Node.js and npm
 RUN apt-get install -y nodejs npm && \
-    npm install -g n
+    npm install -g n && \
+    n 20
 
 # Install Java 11 (Amazon Corretto)
 RUN wget -O- https://apt.corretto.aws/corretto.key | apt-key add - && \

--- a/scala/build/mantic.Dockerfile
+++ b/scala/build/mantic.Dockerfile
@@ -11,11 +11,14 @@ PATH="/home/qa/.yarn/bin:/home/qa/.local/bin:${PATH}" \
 QA_PATH="/home/qa/code"
 
 # Update package index and install system dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
     git curl iputils-ping telnet vim gnupg unzip wget python3 python3-venv \
     postgresql-client default-jre default-jdk apt-transport-https ca-certificates \
     software-properties-common chromium-bsu chromium-browser xvfb python3-full \
-    make build-essential 
+    make build-essential && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Create a virtual environment
 RUN python3 -m venv /venv

--- a/scala/build/mantic.Dockerfile.deprecated
+++ b/scala/build/mantic.Dockerfile.deprecated
@@ -11,6 +11,10 @@ PATH="/home/qa/.yarn/bin:/home/qa/.local/bin:${PATH}" \
 QA_PATH="/home/qa/code"
 
 # Update package index and install system dependencies
+# Deprecated:v2024.4.1
+# The error indicates that the repositories for the mantic release 
+# do not have a Release file, which means they are not available. 
+# You can switch to a stable Ubuntu release like jammy (22.04 LTS) to resolve this issue.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     git curl iputils-ping telnet vim gnupg unzip wget python3 python3-venv \

--- a/ubuntu/latest.Dockerfile
+++ b/ubuntu/latest.Dockerfile
@@ -1,6 +1,12 @@
 # Use the official base image
 FROM ubuntu:latest
 
+# https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images
+# LABEL org.opencontainers.image.description="Ubuntu latest"
+LABEL org.opencontainers.image.description DESCRIPTION="Ubuntu latest"
+LABEL org.opencontainers.image.source=https://github.com/lecaoquochung/docker-images/blob/main/ubuntu/latest.Dockerfile
+LABEL org.opencontainers.image.licenses=MIT
+
 # Update package index and install dependencies
 RUN apt-get update && \
     apt-get install -y git curl iputils-ping telnet vim unzip

--- a/ubuntu/qa.Dockerfile
+++ b/ubuntu/qa.Dockerfile
@@ -47,7 +47,7 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
 # Install Node.js and npm
 RUN apt-get install -y nodejs npm && \
     npm install -g n && \
-    n stable
+    n 20
 
 # Install Java 11 (Amazon Corretto)
 RUN wget -O- https://apt.corretto.aws/corretto.key | apt-key add - && \

--- a/ubuntu/qa.Dockerfile
+++ b/ubuntu/qa.Dockerfile
@@ -46,7 +46,8 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
 
 # Install Node.js and npm
 RUN apt-get install -y nodejs npm && \
-    npm install -g n
+    npm install -g n && \
+    n stable
 
 # Install Java 11 (Amazon Corretto)
 RUN wget -O- https://apt.corretto.aws/corretto.key | apt-key add - && \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes v2024.4.1

- **CI/CD Updates**
  - Deprecated `build-scala-mantic` job in GitHub Actions workflows
  - Added new `build-ubuntu-latest` job for Docker image handling
  - Introduced new jobs requiring manual execution for various environments
  - Enhanced clarity and organization of CI workflows
  - Added a new GitHub Actions workflow for automating the release process

- **Docker Images**
  - Updated base Node.js image to version 22.12.0
  - Standardized Node.js version to 20 across environments
  - Streamlined dependency installation in Dockerfiles
  - Improved cleanup steps in Dockerfiles to minimize image size
  - Added new Redis Dockerfile with metadata labels
  - Enhanced Ubuntu Dockerfile with additional metadata labels

- **Documentation**
  - Added comments to clarify configuration purposes
  - Improved workflow and Dockerfile documentation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->